### PR TITLE
Be the gnoll.

### DIFF
--- a/crawl-ref/source/species-data.h
+++ b/crawl-ref/source/species-data.h
@@ -395,7 +395,7 @@ static const map<species_type, species_def> species_data =
     MONS_GNOLL,
     HT_LAND, US_ALIVE, SIZE_MEDIUM,
     10, 8, 7, // 25
-    { STAT_STR, STAT_INT, STAT DEX }, 5,
+    { STAT_STR, STAT_INT, STAT_DEX }, 5,
     { { MUT_CARNIVOROUS, 3, 1 }, { MUT_SHAGGY_FUR, 1, 1 }, 
     { MUT_SHAGGY_FUR, 1, 14 }, { MUT_SHAGGY_FUR, 1, 27 }, },
     {},


### PR DESCRIPTION
Adds playable gnolls to gnollcrawl.

Admittedly a boring species that would probably not be worth adding to crawl in general, however it seems fitting for this fork.